### PR TITLE
changed list name

### DIFF
--- a/experimental/openconfig/policy/routing-policy.yang
+++ b/experimental/openconfig/policy/routing-policy.yang
@@ -208,7 +208,7 @@ module routing-policy {
             reference the set in match conditions";
       }
 
-      list neighbor {
+      list neighbor-info {
         key "address";
         description
             "list of addresses that are part of the neighor set";


### PR DESCRIPTION
changed list name 'neighbor' to 'neighbor-info' because of the conflict with neighbor in bgp.yang.
