### PR TITLE
Use global-addressfamily-configuration and Comment out bgp-group-common-configuration

### DIFF
--- a/experimental/openconfig/bgp/bgp.yang
+++ b/experimental/openconfig/bgp/bgp.yang
@@ -618,7 +618,7 @@ module bgp {
       uses bgp-common-configuration;
       uses bgp-mp:global-address-family-configuration;
       uses bgp-group-neighbor-common-configuration;
-      uses bgp-group-common-configuration;
+      //uses bgp-group-common-configuration;
 
       // list of configurations for neighbors in this peer group
       uses bgp-neighbor-configuration;

--- a/experimental/openconfig/bgp/bgp.yang
+++ b/experimental/openconfig/bgp/bgp.yang
@@ -577,7 +577,7 @@ module bgp {
 
       }
       uses bgp-common-configuration;
-      uses bgp-mp:address-family-configuration;
+      uses bgp-mp:global-address-family-configuration;
       uses bgp-group-neighbor-common-configuration;
       uses bgp-op:bgp-op-neighbor-group;
     }
@@ -616,7 +616,7 @@ module bgp {
       }
       uses bgp-op:bgp-op-peergroup-group;
       uses bgp-common-configuration;
-      uses bgp-mp:address-family-configuration;
+      uses bgp-mp:global-address-family-configuration;
       uses bgp-group-neighbor-common-configuration;
       uses bgp-group-common-configuration;
 


### PR DESCRIPTION
replaced address-family-configuration with global-address-family-configuration at list 'peer-group' and list 'neighbor' in in bgp.yang.
And also commented out the use of bgp-group-common-configuration at list 'peer-group' because of the conflict of use-multi-paths container in bgp.yang.
