### PR TITLE
bgp-policy: add a leaf to prepend a specific AS number

### DIFF
--- a/experimental/openconfig/bgp/bgp-policy.yang
+++ b/experimental/openconfig/bgp/bgp-policy.yang
@@ -416,9 +416,21 @@ module bgp-policy {
             "action to prepend local AS number to the AS-path a
         specified number of times";
 
+        leaf as {
+          type union {
+            type inet:as-number;
+            type string {
+              pattern "last-as";
+            }
+          }
+          description
+            "autonomous system number or 'last-as' which means
+            the leftmost as number in the AS-path to be prepended";
+        }
+
         leaf repeat-n {
           type uint8;
-          description "number of times to prepend the local AS
+          description "number of times to prepend the specific AS
           number";
         }
       }


### PR DESCRIPTION
This commit is for prepending a specific AS number in the AS_PATH attribute.
The new leaf for AS number is added and defined as union type.
